### PR TITLE
fix: windowsでホットリロードされない問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,7 @@ services:
       - 3000:3000
     volumes:
       - ./src:/workspace
+    environment:
+      - WATCHPACK_POLLING=true
     working_dir: /workspace
     command: yarn dev


### PR DESCRIPTION
# 改善した問題
- windowsでホットリロードされない問題

## 原因
- docker-compose.ymlで設定が必要だった

## 確認事項
- windowsでの動作確認 → ホットリロードされた
- macでの動作確認 → ホットリロードされた